### PR TITLE
[SOL-63] Support validation for spl-2022 accounts

### DIFF
--- a/native-programs/fusion-swap-native/src/validation_helpers.rs
+++ b/native-programs/fusion-swap-native/src/validation_helpers.rs
@@ -40,9 +40,7 @@ pub fn assert_token_account(
     // Decode account data
     let data: &[u8] = &mut account_info.data.borrow();
 
-    // Unpack the data using spl-2022 account deserialization
-    // which should also work with spl-token accounts, because of
-    // backward compatibility.
+    // Unpack the data using spl-2022 account deserialization because of backward compatibility with spl-token.
     let acc_data = StateWithExtensions::<Account>::unpack(data)?;
 
     // Check mint


### PR DESCRIPTION

#### Description

Add support for spl-2022 token in token account validators. The implementation relies on the fact that spl-2022 is backward compatible with spl-token mints. So we just swap out the spl-token account deserialization with spl-token-2022, and we get spl-token and token-2022 compatibility in token account validations.

Resolves point 2) from [SOL-63](https://1inch.atlassian.net/jira/software/c/projects/SOL/boards/681?selectedIssue=SOL-63&useStoredSettings=true) task.


[SOL-63]: https://1inch.atlassian.net/browse/SOL-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ