### PR TITLE
[SOL-61] Fix Issue: Maker and taker assets can be identical

### DIFF
--- a/programs/fusion-swap/src/error.rs
+++ b/programs/fusion-swap/src/error.rs
@@ -20,4 +20,6 @@ pub enum EscrowError {
     InconsistentProtocolFeeConfig,
     #[msg("Inconsistent integrator fee config")]
     InconsistentIntegratorFeeConfig,
+    #[msg("Maker and taker assets cannot be the same")]
+    SameAsset,
 }

--- a/programs/fusion-swap/src/lib.rs
+++ b/programs/fusion-swap/src/lib.rs
@@ -294,6 +294,9 @@ pub struct Create<'info> {
     /// Source asset
     src_mint: Box<InterfaceAccount<'info, Mint>>,
     /// Destination asset
+    #[account(
+        constraint = dst_mint.key() != src_mint.key() @ EscrowError::SameAsset
+    )]
     dst_mint: Box<InterfaceAccount<'info, Mint>>,
 
     /// Maker's ATA of src_mint


### PR DESCRIPTION
#### Description
### Summary
This update adds a constraint to prevent orders where `maker` and `taker` assets are the same.

### Changes
Added a constraint in `Create` instruction to ensure `src_mint != dst_mint`.
Added error for the case with the same assets.

### Reasoning
- Prevents unintended self-trades and circular transactions.
- Avoids potential fee farming exploits.
- Ensures proper order execution without logical conflicts.