### PR TITLE
[SOL-66] Rename EscrowError to FusionError

### DIFF
--- a/native-programs/fusion-swap-native/src/error.rs
+++ b/native-programs/fusion-swap-native/src/error.rs
@@ -1,7 +1,7 @@
 use spl_program_error::num_traits;
 use spl_program_error::spl_program_error;
 #[spl_program_error]
-pub enum EscrowError {
+pub enum FusionError {
     #[error("A token mint constraint was violated")]
     ConstraintTokenMint = 2014,
     #[error("A signer constraint was violated")]

--- a/programs/fusion-swap/src/error.rs
+++ b/programs/fusion-swap/src/error.rs
@@ -1,7 +1,7 @@
 use anchor_lang::error_code;
 
 #[error_code]
-pub enum EscrowError {
+pub enum FusionError {
     #[msg("Inconsistent native dst trait")]
     InconsistentNativeDstTrait,
     #[msg("Invalid amount")]


### PR DESCRIPTION
#### Description
Rename error struct after escrow creation was avoided
