### PR TITLE
[SOL-70] Fix CI warnings by fixing rust toolchain version

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -8,7 +8,7 @@ inputs:
   rustc-version:
     description: "Rust version"
     required: true
-    default: "stable"
+    default: "1.82.0"
   solana-version:
     description: "Solana version"
     required: true
@@ -29,7 +29,7 @@ runs:
 
     # Rust and Cargo
     - name: Set up Rust
-      uses: dtolnay/rust-toolchain@1.82.0
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.rustc-version }}
         components: clippy, rustfmt

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
 channel = "1.82.0"
-components = ["rustfmt", "rustc", "cargo", "rust-analyzer", "clippy", "rust-std"]
-targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-gnu" ]
+profile = "default"


### PR DESCRIPTION
#### Description

Pins rust version that the CI uses, and also pins rust version that is used for local builds using `rust-toolchain.toml` file.
