### PR TITLE
Remove redundant `mut` on escrow account in cancel

### DIFF
--- a/programs/fusion-swap/src/lib.rs
+++ b/programs/fusion-swap/src/lib.rs
@@ -456,7 +456,6 @@ pub struct Cancel<'info> {
 
     /// Account to store order conditions
     #[account(
-        mut,
         seeds = [
             "escrow".as_bytes(),
             maker.key().as_ref(),


### PR DESCRIPTION
#### Description

`mut` modifier isn't needed on `escrow` account in `cancel` endpoint. This PR removes it.
