### PR TITLE
Pin anchor version to 0.30.1 on CI

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -64,7 +64,7 @@ runs:
     # Anchor
     - name: Install Anchor CLI
       shell: bash
-      run: cargo install anchor-cli
+      run: cargo install anchor-cli --version 0.30.1
 
     # Verifications
     - name: Verify Yarn installation


### PR DESCRIPTION
#### Description

New version of Anchor has been released recently, and using it introduced build failures ([link to the failed job](https://github.com/1inch/solana-fusion-protocol/actions/runs/13765072681/job/38489517919?pr=54#step:3:1149)). To prevent these build failure, this PR pins Anchor version on CI to 0.30.1, while the update itself will be done in the scope of the [appropriate issue](https://1inch.atlassian.net/browse/SOL-76)
