### PR TITLE
add reward_limit param

### DIFF
--- a/programs/fusion-swap/src/lib.rs
+++ b/programs/fusion-swap/src/lib.rs
@@ -355,8 +355,8 @@ pub mod fusion_swap {
             reduced_order.cancellation_auction_duration,
             reduced_order.fee.max_cancellation_premium,
         );
-        let maker_refund =
-            ctx.accounts.escrow_src_ata.to_account_info().lamports() - std::cmp::min(cancellation_premium, reward_limit);
+        let maker_refund = ctx.accounts.escrow_src_ata.to_account_info().lamports()
+            - std::cmp::min(cancellation_premium, reward_limit);
         // Transfer all the remaining lamports to the resolver first
         close_account(CpiContext::new_with_signer(
             ctx.accounts.src_token_program.to_account_info(),

--- a/tests/suits/cancel-by-resolver.ts
+++ b/tests/suits/cancel-by-resolver.ts
@@ -347,7 +347,9 @@ describe("Cancel by Resolver", () => {
     expect(
       (await provider.connection.getAccountInfo(state.alice.keypair.publicKey))
         .lamports
-    ).to.be.eq(makerNativeBalanceBefore + tokenAccountRent - resolverPremium.toNumber());
+    ).to.be.eq(
+      makerNativeBalanceBefore + tokenAccountRent - resolverPremium.toNumber()
+    );
     expect(
       (await provider.connection.getAccountInfo(state.bob.keypair.publicKey))
         .lamports


### PR DESCRIPTION
- added the `reward_limit` field, which allows the resolver to limit their reward for calling `cancel_by_resolver` at their discretion.