### PR TITLE
[SOL-91] Audit issue: Varying CU due to search for canonical bump

### DIFF
--- a/programs/fusion-swap/src/lib.rs
+++ b/programs/fusion-swap/src/lib.rs
@@ -481,7 +481,7 @@ pub struct Fill<'info> {
     /// Account allowed to fill the order
     #[account(
         seeds = [whitelist::RESOLVER_ACCESS_SEED, taker.key().as_ref()],
-        bump,
+        bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
     resolver_access: Account<'info, whitelist::ResolverAccess>,
@@ -617,7 +617,7 @@ pub struct CancelByResolver<'info> {
     /// Account allowed to cancel the order
     #[account(
         seeds = [whitelist::RESOLVER_ACCESS_SEED, resolver.key().as_ref()],
-        bump,
+        bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
     resolver_access: Account<'info, whitelist::ResolverAccess>,

--- a/programs/whitelist/src/lib.rs
+++ b/programs/whitelist/src/lib.rs
@@ -22,7 +22,8 @@ pub mod whitelist {
     }
 
     /// Registers a new user to the whitelist
-    pub fn register(_ctx: Context<Register>, _user: Pubkey) -> Result<()> {
+    pub fn register(ctx: Context<Register>, _user: Pubkey) -> Result<()> {
+        ctx.accounts.resolver_access.bump = ctx.bumps.resolver_access;
         Ok(())
     }
 
@@ -129,4 +130,6 @@ pub struct WhitelistState {
 
 #[account]
 #[derive(InitSpace)]
-pub struct ResolverAccess {}
+pub struct ResolverAccess {
+    pub bump: u8,
+}


### PR DESCRIPTION
#### Description

Store canonical bump in `resolver_access` account and use it in `fill` and `cancel_by_resolver` endpoint instead of calculating. Add the respective test to `Whitelist` test suite.

According to the transaction costs tests, CU for `fill` endpoint has been decreased by 2974 CU (from 52571 to 49597) after this change. 

The bump for `escrow` account is still being calculated: it needs to be stored in the `escrow` PDA itself, but we don't create it intentionally to avoid charging rent from maker and make the transactions cheaper.