### PR TITLE
[SOL-91] Audit issue: `create` can be griefed by creating the escrow ATA ahead of it

### DIFF
--- a/programs/fusion-swap/src/lib.rs
+++ b/programs/fusion-swap/src/lib.rs
@@ -438,7 +438,7 @@ pub struct Create<'info> {
 
     /// ATA of src_mint to store escrowed tokens
     #[account(
-        init,
+        init_if_needed,
         payer = maker,
         associated_token::mint = src_mint,
         associated_token::authority = escrow,


### PR DESCRIPTION
#### Description

Use `init_if_needed` for `escrow_ata` account in `create` instruction to avoid DoS attack by creating the `escrow_ata` beforehand and add the test for it.

It seem to not introduce any attack vector because the only thing attacker can do is create the ata and optionally send some tokens to it. Creation of the ata is handled by adding `init_if_needed`, while sending the tokens will only lead for maker to receive more dst tokens than expected.
