### PR TITLE
[SOL-91] Audit issue: Takers can fill expired orders

### DIFF
--- a/programs/fusion-swap/src/lib.rs
+++ b/programs/fusion-swap/src/lib.rs
@@ -59,7 +59,7 @@ pub mod fusion_swap {
         );
 
         require!(
-            Clock::get()?.unix_timestamp <= order.expiration_time as i64,
+            Clock::get()?.unix_timestamp < order.expiration_time as i64,
             FusionError::OrderExpired
         );
 


### PR DESCRIPTION
#### Description

`fill` and `cancel_by_resolver` endpoints treat expired orders differently: the former includes the `expiration_time` point to the order lifetime, while the latter excludes. This PR fixes the `fill` endpoint to reject filling the order at the moment of `expiration_time` to be consistent with `cancel_by_resolver` logic.

Apart from that, this PR also fixes handling of `expiration_time` in the `create` endpoint to be consistent with `fill` and `cancel_by_resolver`
