### PR TITLE
[SOL-98] Audit issue: Missing mut Annotation on maker_receiver Account in Fill Instruction

### DIFF
--- a/programs/fusion-swap/src/lib.rs
+++ b/programs/fusion-swap/src/lib.rs
@@ -491,6 +491,7 @@ pub struct Fill<'info> {
     maker: UncheckedAccount<'info>,
 
     /// CHECK: maker_receiver only has to be equal to escrow parameter
+    #[account(mut)]
     maker_receiver: UncheckedAccount<'info>,
 
     /// Maker asset


### PR DESCRIPTION
#### Description

`maker_receiver` account in `fill` instruction needs to be marked as `mut`. Currently it's not writeable, and in the case when `dstAssetIsNative = true` and `maker_receiver` different from `maker` the program fails with `Cross-program invocation with unauthorized signer or writable account` error. Also add a test for this case.
