### PR TITLE
[SOL-99] Audit issue: N-04 Redundant .key() Call on a Pubkey Value

### DIFF
--- a/programs/whitelist/src/lib.rs
+++ b/programs/whitelist/src/lib.rs
@@ -35,7 +35,7 @@ pub mod whitelist {
     /// Transfers ownership of the whitelist to a new owner
     pub fn transfer_ownership(ctx: Context<TransferOwnership>, _new_owner: Pubkey) -> Result<()> {
         let whitelist_state = &mut ctx.accounts.whitelist_state;
-        whitelist_state.owner = _new_owner.key();
+        whitelist_state.owner = _new_owner;
         Ok(())
     }
 }


### PR DESCRIPTION
#### Description

This PR removes redundant `key()` call on the `Pubkey` value in the whitelist program.
