### PR TITLE
[SOL-99] Audit issue: N-03 Misleading Underscore Prefix on Used Argument _new_owner

### DIFF
--- a/programs/whitelist/src/lib.rs
+++ b/programs/whitelist/src/lib.rs
@@ -33,9 +33,9 @@ pub mod whitelist {
     }
 
     /// Transfers ownership of the whitelist to a new owner
-    pub fn transfer_ownership(ctx: Context<TransferOwnership>, _new_owner: Pubkey) -> Result<()> {
+    pub fn transfer_ownership(ctx: Context<TransferOwnership>, new_owner: Pubkey) -> Result<()> {
         let whitelist_state = &mut ctx.accounts.whitelist_state;
-        whitelist_state.owner = _new_owner;
+        whitelist_state.owner = new_owner;
         Ok(())
     }
 }


### PR DESCRIPTION
#### Description

This PR removes misleading underscore prefix from `_new_owner` account in whitelist program.
