### PR TITLE
Use correct error

### DIFF
--- a/programs/fusion-swap/src/lib.rs
+++ b/programs/fusion-swap/src/lib.rs
@@ -255,7 +255,7 @@ pub mod fusion_swap {
                         .accounts
                         .integrator_dst_acc
                         .as_ref()
-                        .ok_or(FusionError::InconsistentProtocolFeeConfig)?
+                        .ok_or(FusionError::InconsistentIntegratorFeeConfig)?
                         .to_account_info();
                 }
             }


### PR DESCRIPTION
#### Description
Use `InconsistentIntegratorFeeConfig` instead of `InconsistentProtocolFeeConfig` when `integrator_fee_amount > 0` and there is no `integrator_dst_acc`.
